### PR TITLE
add excludeEnvVariables option with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ The following configuration options are available:
 {
   theme: 'okaidia', // The prismjs theme to use
   disabledForXHR: true // Disable the middleware for XHR requests
+  excludeEnvVariables: [], // Name of environment variables to exclude
   disableSourceMapSupport: false // Disables support for sourcemaps
 }
 ```

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 const defaultOptions = {
   disabledForXHR: true,
   disableSourceMapSupport: false,
+  excludeEnvVariables: [],
   theme: 'okaidia'
 };
 

--- a/src/main.js
+++ b/src/main.js
@@ -115,8 +115,9 @@ function parseStack(opts, error) {
   return results.then(r => r.filter(i => i));
 }
 
-function getEnvironment() {
-  return util.toKeyValueList(process.env);
+function getEnvironment(opts) {
+  const environment = util.toKeyValueList(process.env);
+  return environment.filter(v => opts.excludeEnvVariables.indexOf(v.key) < 0);
 }
 
 function getGlobals() {
@@ -167,7 +168,7 @@ module.exports = function main(opts, error, req) {
       headers: getHeaders(req),
       request: getRequest(req),
       stack,
-      environment: getEnvironment(),
+      environment: getEnvironment(opts),
       globals: getGlobals(),
       process: getProcess()
     };

--- a/tests/express.js
+++ b/tests/express.js
@@ -10,23 +10,35 @@ const stack = require('../index').express;
 let app;
 let server;
 
-beforeEach(done => {
-  app = express();
-
-  server = app.listen(3000, done);
-});
-
-afterEach(() => {
-  server.close();
-});
-
 function checkBody(body) {
   const html = cheerio.load(body);
 
   expect(html('title').text()).to.contain('Exception Page');
 }
 
-describe('#stack', () => {
+function checkEnvVarsInclude(body, envVar) {
+  const html = cheerio.load(body);
+
+  expect(html('div.environment').text()).to.contain(envVar);
+}
+
+function checkEnvVarsExclude(body, envVar) {
+  const html = cheerio.load(body);
+
+  expect(html('div.environment').text()).to.not.contain(envVar);
+}
+
+describe('#stack with default config', () => {
+  beforeEach(done => {
+    app = express();
+
+    server = app.listen(3000, done);
+  });
+
+  afterEach(() => {
+    server.close();
+  });
+
   it('fails when NODE_ENV="production"', () => {
     process.env.NODE_ENV = 'production';
 
@@ -63,6 +75,62 @@ describe('#stack', () => {
     request('http://localhost:3000/', (error, response, body) => {
       expect(response.statusCode).to.equal(500);
       checkBody(body);
+      done();
+    });
+  });
+});
+
+describe('#stack with custom excludeEnvVariables config', () => {
+  const testEnvVarName = 'TEST_ENV_VAR';
+
+  beforeEach(done => {
+    process.env[testEnvVarName] = 'Hello World';
+
+    app = express();
+    server = app.listen(3000, done);
+  });
+
+  afterEach(() => {
+    server.close();
+  });
+
+  it('has env variable when not excluded', done => {
+    app.use((req, res, next) => {
+      setImmediate(() => {
+        next(new TypeError('Hello World'));
+      });
+    });
+    app.use(stack());
+
+    request('http://localhost:3000/', (error, response, body) => {
+      expect(response.statusCode).to.equal(500);
+
+      checkBody(body);
+      checkEnvVarsInclude(body, testEnvVarName);
+      done();
+    });
+  });
+
+  it('miss env variable when excluded', done => {
+    const excluded = [];
+    excluded.push(testEnvVarName);
+
+    app.use((req, res, next) => {
+      setImmediate(() => {
+        next(new TypeError('Hello World'));
+      });
+    });
+    app.use(
+      stack({
+        excludeEnvVariables: excluded
+      })
+    );
+
+    request('http://localhost:3000/', (error, response, body) => {
+      expect(response.statusCode).to.equal(500);
+
+      checkBody(body);
+      checkEnvVarsExclude(body, testEnvVarName);
       done();
     });
   });

--- a/tests/koa.js
+++ b/tests/koa.js
@@ -10,25 +10,37 @@ const stack = require('../index').koa;
 let app;
 let server;
 
-beforeEach(done => {
-  app = new Koa();
-
-  app.use(stack());
-
-  server = app.listen(3000, done);
-});
-
-afterEach(() => {
-  server.close();
-});
-
 function checkBody(body) {
   const html = cheerio.load(body);
 
   expect(html('title').text()).to.contain('Exception Page');
 }
 
-describe('#stack', () => {
+function checkEnvVarsInclude(body, envVar) {
+  const html = cheerio.load(body);
+
+  expect(html('div.environment').text()).to.contain(envVar);
+}
+
+function checkEnvVarsExclude(body, envVar) {
+  const html = cheerio.load(body);
+
+  expect(html('div.environment').text()).to.not.contain(envVar);
+}
+
+describe('#stack with default config', () => {
+  beforeEach(done => {
+    app = new Koa();
+
+    app.use(stack());
+
+    server = app.listen(3000, done);
+  });
+
+  afterEach(() => {
+    server.close();
+  });
+
   it('fails when NODE_ENV="production"', () => {
     process.env.NODE_ENV = 'production';
 
@@ -48,6 +60,61 @@ describe('#stack', () => {
       expect(response.statusCode).to.equal(500);
 
       checkBody(body);
+      done();
+    });
+  });
+});
+
+describe('#stack with custom excludeEnvVariables config', () => {
+  const testEnvVarName = 'TEST_ENV_VAR';
+
+  beforeEach(done => {
+    app = new Koa();
+    process.env[testEnvVarName] = 'Hello World';
+    done();
+  });
+
+  afterEach(() => {
+    server.close();
+  });
+
+  it('has env variable when not excluded', done => {
+    app.use(stack());
+    server = app.listen(3000);
+
+    app.use(async () => {
+      throw new TypeError('Hello World');
+    });
+
+    request('http://localhost:3000/', (error, response, body) => {
+      expect(response.statusCode).to.equal(500);
+
+      checkBody(body);
+      checkEnvVarsInclude(body, testEnvVarName);
+      done();
+    });
+  });
+
+  it('miss env variable when excluded', done => {
+    const excluded = [];
+    excluded.push(testEnvVarName);
+
+    app.use(
+      stack({
+        excludeEnvVariables: excluded
+      })
+    );
+    server = app.listen(3000);
+
+    app.use(async () => {
+      throw new TypeError('Hello World');
+    });
+
+    request('http://localhost:3000/', (error, response, body) => {
+      expect(response.statusCode).to.equal(500);
+
+      checkBody(body);
+      checkEnvVarsExclude(body, testEnvVarName);
       done();
     });
   });


### PR DESCRIPTION
In some cases you might want to avoid showing all the environment variables on the error page. With the excludeEnvVariables option you can configure this middleware to exclude some variables by name.